### PR TITLE
Make example settings for suitable dev workflow

### DIFF
--- a/course/settings.py.example
+++ b/course/settings.py.example
@@ -121,7 +121,7 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
-STATIC_URL = '/kurse/static/'
+STATIC_URL = '/static/'
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "static"),


### PR DESCRIPTION
The current example config assumes deployment of the app where static files can be reached on
`http://HOST/kurse/static`, which is not true for a simple dev environment.

I think the sample config should be such that `manage.py runserver` will give you a working 
instance for developing. The deployment on iFSR servers can still use a different config.