### PR TITLE
Fix error on course enrolment (closes #110)

### DIFF
--- a/course/templates/course/info.html
+++ b/course/templates/course/info.html
@@ -77,7 +77,9 @@
       <hr class="m-0">
       <div class="card-body">
         <h5 class="card-title">{% trans 'Status' %}</h5>
-        {% if course.active %}
+          {% if course.is_archived %}
+            <span class="badge badge-light">{% trans 'archived' %}</span>
+          {% elif course.active %}
             {% if course.saturated %}
               <span class="badge badge-danger">{% trans 'full' %}</span>
             {% else %}
@@ -123,7 +125,7 @@
         {% else %}
           <form action="{% url 'register-course' course.id %}{% if target %}?target={{ target }}{% endif %}" method="post">
             {% csrf_token %}
-            {% if course.active %}
+            {% if course.active and not course.is_archived %}
               {% if course.joinable %}
                 <input class="btn btn-primary mr-2" type="submit" value="{% trans 'Enroll' %}">
               {% else %}

--- a/course/views/enroll.py
+++ b/course/views/enroll.py
@@ -30,6 +30,8 @@ def add(request, course_id):
             course.enroll(stud)
         except Course.IsInactive:
             return HttpResponseForbidden()
+        except Course.IsArchived:
+            return HttpResponseForbidden()
 
     # redirect to course overview or specified target
     return redirect_unless_target(request, 'course', course_id)


### PR DESCRIPTION
The course detail view did not consider the archival state of a course, which shouldn't have been a problem (archived courses are never listed anywhere), but recently we received a number of Server Errors from users trying to register for an archived course. This is now fixed by properly handling the archival state in the UI and backend.