### PR TITLE
Bump Django to 3.2 LTS

### DIFF
--- a/course/settings.py.example
+++ b/course/settings.py.example
@@ -88,6 +88,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # django-guardian configuration
 
 AUTHENTICATION_BACKENDS = (

--- a/course/templates/base-shell.html
+++ b/course/templates/base-shell.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 <!DOCTYPE html>
 <html lang="en">

--- a/course/util/permissions.py
+++ b/course/util/permissions.py
@@ -26,7 +26,7 @@ def needs_teacher_permissions(func):
         try:
             curr_course = Course.objects.get(id=course_id) if not isinstance(course_id, Course) else course_id
         except Course.DoesNotExist:
-            return db_error(_('This course does not seem to exist, sorry.'))
+            return db_error(request, _('This course does not seem to exist, sorry.'))
         if has_teacher_permissions(request.user.userinformation, curr_course):
             return func(request, course_id, *args, **kwargs)
         else:

--- a/course/views/course.py
+++ b/course/views/course.py
@@ -2,7 +2,7 @@ from django.contrib.auth.decorators import permission_required, login_required
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.http import HttpRequest
-from django.shortcuts import redirect, render_to_response, render
+from django.shortcuts import redirect, render
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from guardian.shortcuts import assign_perm
@@ -75,7 +75,7 @@ def course(request: HttpRequest, course_id: str):
             context
         )
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
 
 @needs_teacher_permissions
@@ -89,7 +89,7 @@ def participants_list(request, course_id):
             {'course': current_course}
         )
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
 
 @needs_teacher_permissions
@@ -105,7 +105,7 @@ def edit_course(request: HttpRequest, course_id: str):
         current_course = Course.objects.get(id=course_id)
         current_schedule = Schedule.objects.get(course_id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
     if request.method == "POST":
         form = CourseForm(request.POST, instance=current_course)
@@ -152,7 +152,7 @@ def toggle(request: HttpRequest, course_id: str, active: bool):
     try:
         curr_course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
     curr_course.active = active
     if not active:
@@ -215,7 +215,7 @@ def delete(request, course_id):
     try:
         course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
     subj = course.subject.name
 
@@ -234,7 +234,7 @@ def add_teacher(request, course_id):
     try:
         curr_course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
     if request.method == 'POST':
         form = AddTeacherForm(request.POST)
@@ -288,9 +288,9 @@ def remove_teacher(request, course_id, teacher_id):
             curr_course
         )
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
     except UserInformation.DoesNotExist:
-        return db_error(_('Requested student does not exist.'))
+        return db_error(request, _('Requested student does not exist.'))
     return redirect_unless_target(request, 'course', course_id)
 
 
@@ -302,7 +302,7 @@ def notify(request: HttpRequest, course_id):
             try:
                 course = Course.objects.get(id=course_id)
             except Course.DoesNotExist:
-                return db_error(_('Requested course does not exist.'))
+                return db_error(request, _('Requested course does not exist.'))
 
             email = request.user.email
             show_sender = form.cleaned_data['show_sender'] and email
@@ -347,9 +347,9 @@ def remove_student(request: HttpRequest, course_id:str, student_id:str):
         course = Course.objects.get(id=course_id)
         course.unenroll(student_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
     except Course.IsEnrolled:
-        return db_error(_('Requested student is not enrolled in this course.'))
+        return db_error(request, _('Requested student is not enrolled in this course.'))
 
     return redirect('course', course_id)
 
@@ -360,7 +360,7 @@ def attendee_list(request, course_id):
         try:
             course = Course.objects.get(id=course_id)
         except Course.DoesNotExist:
-            return db_error(_('Requested course does not exist.'))
+            return db_error(request, _('Requested course does not exist.'))
 
         # handle empty string (== no number) as input
         try:
@@ -385,7 +385,7 @@ def contact_teachers(request, course_id):
             try:
                 course = Course.objects.get(id=course_id)
             except Course.DoesNotExist:
-                return db_error(_('Requested course does not exist.'))
+                return db_error(request, _('Requested course does not exist.'))
 
             subject = "[CM contact form] " + form.subject
             content = form.content + CONTACT_FOOTER + request.user.email

--- a/course/views/enroll.py
+++ b/course/views/enroll.py
@@ -18,7 +18,7 @@ def add(request, course_id):
     try:
         course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
     session = request.session
 
     if course.is_participant(stud):
@@ -44,7 +44,7 @@ def remove(request, course_id):
     try:
         course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
     ps = course.participants
 
     if course.is_participant(stud):

--- a/course/views/index.py
+++ b/course/views/index.py
@@ -1,5 +1,5 @@
 from course.models import news
-from django.shortcuts import render, render_to_response
+from django.shortcuts import render
 from django.utils.translation import ugettext as _
 
 
@@ -25,13 +25,13 @@ def privacy_policy(request):
 
 
 def handler404(request, exception, template_name="error/404.html"):
-    response = render_to_response(template_name)
+    response = render(request, template_name)
     response.status_code = 404
     return response
 
 
 def handler500(request): #t, exception, template_name="error/500.html"):
     template_name = "error/500.html"
-    response = render_to_response(template_name)
+    response = render(request, template_name)
     response.status_code = 500
     return response

--- a/course/views/news.py
+++ b/course/views/news.py
@@ -54,7 +54,7 @@ def edit(request: HttpRequest, news_id: str):
     try:
         cur_news = news.News.objects.get(id=news_id)
     except news.News.DoesNotExist:
-        return db_error(_('Requested News does not exist.'))
+        return db_error(request, _('Requested News does not exist.'))
 
     if request.method == 'POST':
         form = NewsForm(request.POST, instance=cur_news)
@@ -90,7 +90,7 @@ def delete(request: HttpRequest, news_id: str):
     try:
         cur_news = news.News.objects.get(id=news_id)
     except news.News.DoesNotExist:
-        return db_error(_('Requested News does not exist.'))
+        return db_error(request, _('Requested News does not exist.'))
 
     cur_news.delete()
     return redirect('index')

--- a/course/views/subject.py
+++ b/course/views/subject.py
@@ -16,7 +16,7 @@ def course_overview(request, subjectname):
     try:
         active_subject = subject.Subject.objects.get(name=subjectname)
     except subject.Subject.DoesNotExist:
-        return db_error(_('Requested subject does not exist.'))
+        return db_error(request, _('Requested subject does not exist.'))
 
     if user.is_authenticated:
         cl = list(filter(
@@ -89,7 +89,7 @@ def edit(request, subjectname):
     try:
         subj = subject.Subject.objects.get(name=subjectname)
     except subject.Subject.DoesNotExist:
-        return db_error(_('Requested subject does not exist.'))
+        return db_error(request, _('Requested subject does not exist.'))
 
     if request.method == 'POST':
         form = SubjectForm(request.POST, instance=subj)
@@ -121,7 +121,7 @@ def delete(request, subjectname):
     try:
         subj = subject.Subject.objects.get(name=subjectname)
     except subject.Subject.DoesNotExist:
-        return db_error(_('Requested subject does not exist.'))
+        return db_error(request, _('Requested subject does not exist.'))
 
     subj.delete()
 

--- a/course/views/time.py
+++ b/course/views/time.py
@@ -21,7 +21,7 @@ def edit_slot(request: HttpRequest, course_id):
     try:
         course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(_('Requested course does not exist.'))
+        return db_error(request, _('Requested course does not exist.'))
 
     schedule = course.schedule
 
@@ -64,7 +64,7 @@ def remove_slot(request, course_id, slot_id):
     try:
         course = Course.objects.get(id=course_id)
     except Course.DoesNotExist:
-        return db_error(
+        return db_error(request, 
             'The specified course does not exist. Please try again. '
             'If this error persists, contact an administrator and include the url "{}"'
             ''.format(request.path)
@@ -73,7 +73,7 @@ def remove_slot(request, course_id, slot_id):
     try:
         course.schedule.slots.get(id=slot_id).delete()
     except (WeeklySlot.DoesNotExist, DateSlot.DoesNotExist):
-        return db_error(
+        return db_error(request, 
             'The slot you\'re trying to remove does not exist. Please try again. '
             'If this error persists, contact an administrator and include the url "{}"'
             ''.format(request.path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-django==2.2.*
+django==3.2.*
 PyYAML>=3
 bleach
 markdown
 requests
-django-modeltranslation==0.13.*
+django-modeltranslation==0.17.*
 # django-modeltranslation
 django-guardian==2.1.*

--- a/user/views/contact.py
+++ b/user/views/contact.py
@@ -19,7 +19,7 @@ def contact_form(request: HttpRequest, user_id: int):
     try:
         user = User.objects.get(id=user_id)
     except User.DoesNotExist:
-        return db_error(_('Requested user does not exist.'))
+        return db_error(request, _('Requested user does not exist.'))
     assert isinstance(user, User)
 
     if request.method == 'POST':

--- a/user/views/user.py
+++ b/user/views/user.py
@@ -62,7 +62,7 @@ def profile(request, user_id=None):
             user = User.objects.get(id=user_id)
             is_own = request.user.id == user.id
         except User.DoesNotExist:
-            return db_error(_('This user does not exist'))
+            return db_error(request, _('This user does not exist'))
 
         template = 'user/public_profile.html'
 

--- a/util/error/reporting.py
+++ b/util/error/reporting.py
@@ -1,8 +1,8 @@
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 
-def db_error(message):
+def db_error(request, message):
     """
     Report a database error in a view.
     """
-    return render_to_response('error/db.html', {'error': message})
+    return render(request, 'error/db.html', {'error': message})


### PR DESCRIPTION
## Changes

This will bump Django to the new version 3.2 (LTS) as well as `django-modeltranslation` to version `0.17.*`.

The latter change became a necessity when I looked up what version of `modeltranslation` is recommended for Django 3.2. As for the compatibility of the code base I just had to remove any occurences of `render_to_response` and the `staticfiles` template module which were both removed in 3.0. The version bump in `django-modeltranslation` yielded no errors or warnings for me so that seems to work fine.

The patch also adds a new setting to the settings file to account for the new data type assigned to primary key fields.

Applying the new migrations worked without problems when using `sqlite3`, I didn't check it with the Postgres backend.

This closes #109.

## Checklist for applying the patch to the deployed version

- [ ] bump the dependencies according to specification
- [ ] add the line `DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'` to `course/settings.py`, as shown in the example file.
- [ ] create a database backup just in case
- [ ] run `python3 manage.py migrate`
- [ ] verify that the system check identifies no errors and user data is still present (i.e., login works)