### PR TITLE
Fix bleach invocation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django==3.2.*
 PyYAML>=3
-bleach
+bleach==5.0.*
 markdown
 requests
 django-modeltranslation==0.17.*

--- a/util/html_clean.py
+++ b/util/html_clean.py
@@ -25,4 +25,4 @@ def clean_all(html):
     """
     Removes *all* html tags.
     """
-    return bleach.clean(html, tags=[], styles=[], attributes=[], strip=True)
+    return bleach.clean(html, tags=[], attributes=[], strip=True)


### PR DESCRIPTION
The last updates on the deploy machine installed a `bleach` version > 3.1.4, after which the library [changed the invocation](https://bleach.readthedocs.io/en/latest/changes.html#version-3-1-4-march-24th-2020) of `clean_all`. This update should fix the Internal Server errror by removing the argument entirely from the call.