### PR TITLE
Remove django-guardian pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ markdown
 requests
 django-modeltranslation==0.17.*
 # django-modeltranslation
-django-guardian==2.1.*
+django-guardian


### PR DESCRIPTION
To the best of my knowledge also the most recent released version of guardian works with django 3.2 and with our usage. So drop the pin.